### PR TITLE
Fix a problem with "key":"value\\"

### DIFF
--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -25,7 +25,7 @@ class Lexer implements \IteratorAggregate
     {
         $inString = false;
         $tokenBuffer = '';
-        $previousByte = null;
+        $escaped = false;
 
         ${' '} = 0;
         ${"\n"} = 0;
@@ -45,11 +45,10 @@ class Lexer implements \IteratorAggregate
                 ++$this->position;
 
                 if ($inString) {
-                    if ($byte === '"' && $previousByte !== '\\') {
+                    if ($byte === '"' && !$escaped) {
                         $inString = false;
-                    } else {
-                        $previousByte = $byte;
                     }
+                    $escaped = ($byte =='\\' && !$escaped);
                     $tokenBuffer .= $byte;
                     continue;
                 }

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -25,7 +25,7 @@ class Lexer implements \IteratorAggregate
     {
         $inString = false;
         $tokenBuffer = '';
-        $escaped = false;
+        $isEscaping = false;
 
         ${' '} = 0;
         ${"\n"} = 0;
@@ -45,10 +45,10 @@ class Lexer implements \IteratorAggregate
                 ++$this->position;
 
                 if ($inString) {
-                    if ($byte === '"' && !$escaped) {
+                    if ($byte === '"' && !$isEscaping) {
                         $inString = false;
                     }
-                    $escaped = ($byte =='\\' && !$escaped);
+                    $isEscaping = ($byte =='\\' && !$isEscaping);
                     $tokenBuffer .= $byte;
                     continue;
                 }

--- a/test/JsonMachineTest/LexerTest.php
+++ b/test/JsonMachineTest/LexerTest.php
@@ -13,4 +13,9 @@ class LexerTest extends \PHPUnit_Framework_TestCase
         $expected = ['{','}','[',']',',',':','null',',','"string"','false',':','true',',','1',',','100000',',','1.555','{','-56',']','""',',','"\\""'];
         $this->assertEquals($expected, iterator_to_array(new Lexer(new \ArrayIterator($data))));
     }
+
+    public function testCorrectlyParsesTwoBackslashesAtTheEndOfAString()
+    {
+        $this->assertEquals(['"test\\\\"', ':'], iterator_to_array(new Lexer(new \ArrayIterator(['"test\\\\":']))));
+    }
 }


### PR DESCRIPTION
My JSON-file has values like this:
"phone":"+254652155251\\"
and it causes the error "Unexpected symbol '<char>' At position <number>".