### PR TITLE
Use a 'token' object-stream between the lexer and parser.

### DIFF
--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -2,12 +2,21 @@
 
 namespace JsonMachine;
 
+use JsonMachine\Token;
+
 class Lexer implements \IteratorAggregate
 {
     /** @var resource */
     private $bytesIterator;
 
-    private $position = 0;
+    /** @var integer */
+    private $position;
+
+    /** @var integer */
+    private $line;
+
+    /** @var integer */
+    private $column;
 
     /**
      * @param \Traversable $bytesIterator
@@ -15,62 +24,106 @@ class Lexer implements \IteratorAggregate
     public function __construct(\Traversable $bytesIterator)
     {
         $this->bytesIterator = $bytesIterator;
+        $this->position = 0;
+        $this->line = 0;
+        $this->column = 0;
     }
-    
+
     /**
      * @return \Generator
      */
     public function getIterator()
     {
-        $inString = false;
-        $tokenBuffer = '';
-        $isEscaping = false;
+        foreach ($this->bytesIterator as $buffer) {
+            for ($i = 0, $l = strlen($buffer); $i < $l; $i++) {
+                $character = $buffer[$i];
 
-        ${' '} = 0;
-        ${"\n"} = 0;
-        ${"\r"} = 0;
-        ${"\t"} = 0;
-        ${'{'} = 1;
-        ${'}'} = 1;
-        ${'['} = 1;
-        ${']'} = 1;
-        ${':'} = 1;
-        ${','} = 1;
+                switch ($character) {
+                    case " ":
+                    case "\t":
+                        break;
 
-        foreach ($this->bytesIterator as $bytes) {
-            $bytesLength = strlen($bytes);
-            for ($i = 0; $i < $bytesLength; ++$i) {
-                $byte = $bytes[$i];
-                ++$this->position;
+                    case "\r":
+                    case "\n":
+                        // advance to next line and reset column
+                        $this->line++;
+                        $this->column = -1;
+                        break;
 
-                if ($inString) {
-                    if ($byte === '"' && !$isEscaping) {
-                        $inString = false;
-                    }
-                    $isEscaping = ($byte =='\\' && !$isEscaping);
-                    $tokenBuffer .= $byte;
-                    continue;
+                    case '{':
+                        yield new Token($this->line, $this->column, Token::OBJECT_START, '{');
+                        break;
+
+                    case '}':
+                        yield new Token($this->line, $this->column, Token::OBJECT_END, '}');
+                        break;
+
+                    case '[':
+                        yield new Token($this->line, $this->column, Token::ARRAY_START, '[');
+                        break;
+
+                    case ']':
+                        yield new Token($this->line, $this->column, Token::ARRAY_END, ']');
+                        break;
+
+                    case ':':
+                        yield new Token($this->line, $this->column, Token::COLON, ':');
+                        break;
+
+                    case ',':
+                        yield new Token($this->line, $this->column, Token::COMMA, ',');
+                        break;
+
+                    case '"':
+                        $value = $character;
+                        $width = 0;
+                        $escaping = false;
+
+                        while (true) {
+                            $char = $buffer[++$i];
+                            $value .= $char;
+                            $width++;
+
+                            if (($char === '"' && !$escaping) || $char === '') {
+                                break;
+                            }
+
+                            $escaping = ($char === '\\' && !$escaping); // deals with escaped back slashes
+                        }
+
+                        yield new Token($this->line, $this->column, Token::SCALAR_STRING, $value);
+
+                        $this->column += $width;
+
+                        break;
+
+                    default:
+                        $value = $character;
+                        $width = 0;
+
+                        while (true) {
+                            $char = isset($buffer[++$i]) ? $buffer[$i] : '';
+
+                            if (in_array($char, ['{', '}', '[', ']', ':', ',', '"', " ", "\t", "\r", "\n", ''])) {
+                                $i--;  // let the outer loop handle these characters
+
+                                break;
+                            }
+
+                            $value .= $char;
+                            $width++;
+                        }
+
+                        yield new Token($this->line, $this->column, Token::SCALAR_CONST, $value);
+
+                        $this->column += $width;
                 }
 
-                if (isset($$byte)) {
-                    if ($tokenBuffer !== '') {
-                        yield $tokenBuffer;
-                        $tokenBuffer = '';
-                    }
-                    if ($$byte) { // is not whitespace
-                        yield $byte;
-                    }
-                } else {
-                    if ($byte === '"') {
-                        $inString = true;
-                    }
-                    $tokenBuffer .= $byte;
-                }
+                $this->column++;
             }
         }
-        if ($tokenBuffer !== '') {
-            yield $tokenBuffer;
-        }
+
+        $this->position = $this->column;
     }
 
     /**

--- a/src/Token.php
+++ b/src/Token.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace JsonMachine;
+
+class Token
+{
+    const SCALAR_CONST = 1;
+    const SCALAR_STRING = 2;
+    const OBJECT_START = 4;
+    const OBJECT_END = 8;
+    const ARRAY_START = 16;
+    const ARRAY_END = 32;
+    const COMMA = 64;
+    const COLON = 128;
+
+    /** @var integer */
+    private $line;
+
+    /** @var integer */
+    private $column;
+
+    /** @var integer */
+    private $type;
+
+    /** @var string */
+    private $value;
+
+    /**
+     * @param integer $line The line number of the lexeme's position. If there are no linebreaks this will be "line 1".
+     * @param integer $column The start position of the lexeme within the line.
+     * @param integer $type One of the class constants.
+     * @param string $value The lexeme of the type, or just an empty value if type is enough.
+     */
+    public function __construct($line, $column, $type, $value = '')
+    {
+        $this->setLine($line);
+        $this->setColumn($column);
+        $this->setType($type);
+        $this->setValue($value);
+    }
+
+    /** @var integer Index starts at one. */
+    public function getLine()
+    {
+        return $this->line;
+    }
+
+    /** @var integer Index starts at zero. */
+    public function getColumn()
+    {
+        return $this->column;
+    }
+
+    /** @var integer */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /** @var string */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    private function setLine($line)
+    {
+        if (!is_integer($line)) {
+            throw new \InvalidArgumentException(sprintf('Invalid type "%s" for line parameter. Please provide an integer.', gettype($line)));
+        }
+
+        $this->line = $line;
+    }
+
+    private function setColumn($column)
+    {
+        if (!is_integer($column)) {
+            throw new \InvalidArgumentException(sprintf('Invalid type "%s" for column parameter. Please provide an integer.', gettype($column)));
+        }
+
+        $this->column = $column;
+    }
+
+    private function setType($type)
+    {
+        if (!is_integer($type)) {
+            throw new \InvalidArgumentException(sprintf('Invalid type "%s" for type parameter. Please use one of the class constants.', gettype($type)));
+        }
+
+        $this->type = $type;
+    }
+
+    private function setValue($value)
+    {
+        if (!is_string($value)) {
+            throw new \InvalidArgumentException(sprintf('Invalid type "%s" for value parameter. Please provide a string.', gettype($value)));
+        }
+
+        $this->value = $value;
+    }
+}

--- a/test/JsonMachineTest/LexerTest.php
+++ b/test/JsonMachineTest/LexerTest.php
@@ -11,11 +11,24 @@ class LexerTest extends \PHPUnit_Framework_TestCase
     {
         $data = ['{}[],:null,"string" false:', 'true,1,100000,1.555{-56]"","\\""'];
         $expected = ['{','}','[',']',',',':','null',',','"string"','false',':','true',',','1',',','100000',',','1.555','{','-56',']','""',',','"\\""'];
-        $this->assertEquals($expected, iterator_to_array(new Lexer(new \ArrayIterator($data))));
+        $lexer = new Lexer(new \ArrayIterator($data));
+
+        $this->assertEquals($expected, $this->flattenToLexemes($lexer));
     }
 
     public function testCorrectlyParsesTwoBackslashesAtTheEndOfAString()
     {
-        $this->assertEquals(['"test\\\\"', ':'], iterator_to_array(new Lexer(new \ArrayIterator(['"test\\\\":']))));
+        $lexer = new Lexer(new \ArrayIterator(['"test\\\\":']));
+
+        $this->assertEquals(['"test\\\\"', ':'], $this->flattenToLexemes($lexer));
+    }
+
+    private function flattenToLexemes(Lexer $lexer)
+    {
+        $tokens = iterator_to_array($lexer);
+
+        return array_map(function ($token) {
+            return $token->getValue();
+        }, $tokens);
     }
 }

--- a/test/JsonMachineTest/TokenTest.php
+++ b/test/JsonMachineTest/TokenTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace JsonMachineTest;
+
+use JsonMachine\Token;
+
+class TokenTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->line = 3;
+        $this->column = 5;
+        $this->type = Token::SCALAR_STRING;
+        $this->value = '"a string literal"';
+    }
+
+    public function testThrowsErrorIfLineIsNotANumber()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid type "string" for line parameter. Please provide an integer.');
+
+        $token = new Token('3', $this->column, $this->type, $this->value);
+    }
+
+    public function testLineIsSet()
+    {
+        $token = new Token($this->line, $this->column, $this->type, $this->value);
+
+        $this->assertSame($this->line, $token->getLine());
+    }
+
+    public function testThrowsErrorIfColumnIsNotANumber()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid type "string" for column parameter. Please provide an integer.');
+
+        $token = new Token($this->line, '5', $this->type, $this->value);
+    }
+
+    public function testColumnIsSet()
+    {
+        $token = new Token($this->line, $this->column, $this->type, $this->value);
+
+        $this->assertSame($this->column, $token->getColumn());
+    }
+
+    public function testThrowsErrorIfTypeIsNotANumber()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid type "string" for type parameter. Please use one of the class constants.');
+
+        $token = new Token($this->line, $this->column, '2', $this->value);
+    }
+
+    public function testTypeIsSet()
+    {
+        $token = new Token($this->line, $this->column, $this->type, $this->value);
+
+        $this->assertSame($this->type, $token->getType());
+    }
+
+    public function testThrowsErrorIfValueIsNotAString()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid type "NULL" for value parameter. Please provide a string.');
+
+        $token = new Token($this->line, $this->column, $this->type, null);
+    }
+
+    public function testValueIsSet()
+    {
+        $token = new Token($this->line, $this->column, $this->type, $this->value);
+
+        $this->assertSame($this->value, $token->getValue());
+    }
+}


### PR DESCRIPTION
I think this will add a lot of benefits, especially in future PRs/commits (I have a few other ideas). Also by adding a 'token' object it starts to reduce complexity in the `Lexer`/`Parser` classes, as seen by the commits (the code is easier to follow along with).

The tokens produced by the lexer also now track the any linebreaks (you will see why in my next PR).

:-)