### PR TITLE
Ignore UTF BOM at the beginning of the stream

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,4 +4,10 @@
             <directory>./test/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -5,10 +5,6 @@ namespace JsonMachine;
 class Lexer implements \IteratorAggregate
 {
     const BOM_UTF8 = "\xEF\xBB\xBF";
-    const BOM_UTF16_BE = "\xFE\xFF";
-    const BOM_UTF16_LE = "\xFF\xFE";
-    const BOM_UTF32_BE = "\x00\x00\xFE\xFF";
-    const BOM_UTF32_LE = "\xFF\xFE\x00\x00";
 
     /** @var resource */
     private $bytesIterator;
@@ -90,18 +86,6 @@ class Lexer implements \IteratorAggregate
                     }
                     $tokenBuffer .= $byte;
                     if($this->position === 3 && $tokenBuffer === self::BOM_UTF8) {
-                        $tokenBuffer = '';
-                    }
-                    if($this->position === 2 && $tokenBuffer === self::BOM_UTF16_BE) {
-                        $tokenBuffer = '';
-                    }
-                    if($this->position === 2 && $tokenBuffer === self::BOM_UTF16_LE) {
-                        $tokenBuffer = '';
-                    }
-                    if($this->position === 4 && $tokenBuffer === self::BOM_UTF32_BE) {
-                        $tokenBuffer = '';
-                    }
-                    if($this->position === 4 && $tokenBuffer === self::BOM_UTF32_LE) {
                         $tokenBuffer = '';
                     }
                     $width++;

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -4,6 +4,12 @@ namespace JsonMachine;
 
 class Lexer implements \IteratorAggregate
 {
+    const BOM_UTF8 = "\xEF\xBB\xBF";
+    const BOM_UTF16_BE = "\xFE\xFF";
+    const BOM_UTF16_LE = "\xFF\xFE";
+    const BOM_UTF32_BE = "\x00\x00\xFE\xFF";
+    const BOM_UTF32_LE = "\xFF\xFE\x00\x00";
+
     /** @var resource */
     private $bytesIterator;
 
@@ -83,6 +89,21 @@ class Lexer implements \IteratorAggregate
                         $inString = true;
                     }
                     $tokenBuffer .= $byte;
+                    if($this->position === 3 && $tokenBuffer === self::BOM_UTF8) {
+                        $tokenBuffer = '';
+                    }
+                    if($this->position === 2 && $tokenBuffer === self::BOM_UTF16_BE) {
+                        $tokenBuffer = '';
+                    }
+                    if($this->position === 2 && $tokenBuffer === self::BOM_UTF16_LE) {
+                        $tokenBuffer = '';
+                    }
+                    if($this->position === 4 && $tokenBuffer === self::BOM_UTF32_BE) {
+                        $tokenBuffer = '';
+                    }
+                    if($this->position === 4 && $tokenBuffer === self::BOM_UTF32_LE) {
+                        $tokenBuffer = '';
+                    }
                     $width++;
                 }
             }

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -4,8 +4,6 @@ namespace JsonMachine;
 
 class Lexer implements \IteratorAggregate
 {
-    const BOM_UTF8 = "\xEF\xBB\xBF";
-
     /** @var resource */
     private $bytesIterator;
 
@@ -31,6 +29,9 @@ class Lexer implements \IteratorAggregate
         $isEscaping = false;
         $width = 0;
         $trackingLineBreak = false;
+
+        // Treat UTF-8 BOM bytes as whitespace
+        ${"\xEF"} = ${"\xBB"} = ${"\xBF"} = 0;
 
         ${' '} = 0;
         ${"\n"} = 0;
@@ -85,9 +86,6 @@ class Lexer implements \IteratorAggregate
                         $inString = true;
                     }
                     $tokenBuffer .= $byte;
-                    if($this->position === 3 && $tokenBuffer === self::BOM_UTF8) {
-                        $tokenBuffer = '';
-                    }
                     $width++;
                 }
             }

--- a/test/JsonMachineTest/LexerTest.php
+++ b/test/JsonMachineTest/LexerTest.php
@@ -15,6 +15,13 @@ class LexerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, iterator_to_array(new Lexer(new \ArrayIterator($data))));
     }
 
+    public function testWithBOM()
+    {
+        $data = ["\xEF\xBB\xBF" . '{}'];
+        $expected = ['{','}'];
+        $this->assertEquals($expected, iterator_to_array(new Lexer(new \ArrayIterator($data))));
+    }
+
     public function testCorrectlyParsesTwoBackslashesAtTheEndOfAString()
     {
         $this->assertEquals(['"test\\\\"', ':'], iterator_to_array(new Lexer(new \ArrayIterator(['"test\\\\":']))));


### PR DESCRIPTION
When the json file stream contains a BOM sequence at the begining, the parser throws an exception and cannot parse the file, even if the encoding is UTF-8.

With this change, the parser ignore the BOM sequence if found.

I included BOM sequences for UTF-16 (BE/LE) and UTF-32 (BE/LE) too.