### PR TITLE
Added unexpected end exception with tests

### DIFF
--- a/src/Exception/UnexpectedEndOfJsonInputException.php
+++ b/src/Exception/UnexpectedEndOfJsonInputException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace JsonMachine\Exception;
+
+class UnexpectedEndOfJsonInputException extends \InvalidArgumentException
+{
+
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -5,6 +5,7 @@ namespace JsonMachine;
 use JsonMachine\Exception\InvalidArgumentException;
 use JsonMachine\Exception\PathNotFoundException;
 use JsonMachine\Exception\SyntaxError;
+use JsonMachine\Exception\UnexpectedEndOfJsonInputException;
 use JsonMachine\JsonDecoder\Decoder;
 use JsonMachine\JsonDecoder\ExtJsonDecoder;
 
@@ -215,6 +216,10 @@ class Parser implements \IteratorAggregate
 
         if ( ! $pathFound) {
             throw new PathNotFoundException("Path '{$this->jsonPointer}' was not found in json stream.");
+        }
+
+        if ($currentLevel > -1){
+            throw new UnexpectedEndOfJsonInputException('JSON format ended unexpectedly');
         }
     }
 

--- a/test/JsonMachineTest/ParserTest.php
+++ b/test/JsonMachineTest/ParserTest.php
@@ -5,6 +5,7 @@ namespace JsonMachineTest;
 use JsonMachine\Exception\InvalidArgumentException;
 use JsonMachine\Exception\PathNotFoundException;
 use JsonMachine\Exception\SyntaxError;
+use JsonMachine\Exception\UnexpectedEndOfJsonInputException;
 use JsonMachine\Lexer;
 use JsonMachine\Parser;
 
@@ -149,6 +150,38 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             ['["string","string",]'],
             ['["string",1eeee1]'],
             ['{"key\u000Z": "non hex key"}']
+        ];
+    }
+
+    /**
+     * @dataProvider dataUnexpectedEndError
+     */
+    public function testUnexpectedEndError($malformedJson, $exception = UnexpectedEndOfJsonInputException::class)
+    {
+        $this->expectException($exception);
+
+        iterator_to_array($this->createParser($malformedJson));
+    }
+
+    public function dataUnexpectedEndError()
+    {
+        return [
+            ['['],
+            ['{'],
+            ['["string"'],
+            ['["string",'],
+            ['[{"string":"string"}'],
+            ['[{"string":"string"},'],
+            ['[{"string":"string"},{'],
+            ['[{"string":"string"},{"str'],
+            ['[{"string":"string"},{"string"'],
+            ['{"string"'],
+            ['{"string":'],
+            ['{"string":"string"'],
+            ['{"string":["string","string"]'],
+            ['{"string":["string","string"'],
+            ['{"string":["string","string",'],
+            ['{"string":["string","string","str']
         ];
     }
 


### PR DESCRIPTION
This modification adds the possibility of detecting when a stream was truncated during transmission. #26 

Possible BC for those who have implemented without considering that possibility, and have not wrapped try-catch for the new exception.

The error is basically a syntax error, but I consider it useful to be able to differentiate it, bearing in mind that the format of the stream itself may be correct, but truncated for external reasons.