### PR TITLE
Allow StreamBytes generator to be iterated more than once

### DIFF
--- a/src/StreamBytes.php
+++ b/src/StreamBytes.php
@@ -24,6 +24,7 @@ class StreamBytes implements \IteratorAggregate
      */
     public function getIterator()
     {
+        rewind($this->stream);
         while ('' !== ($bytes = fread($this->stream, 1024 * 8))) {
             yield $bytes;
         }

--- a/test/JsonMachineTest/JsonMachineTest.php
+++ b/test/JsonMachineTest/JsonMachineTest.php
@@ -15,6 +15,8 @@ class JsonMachineTest extends \PHPUnit_Framework_TestCase
     {
         $iterator = call_user_func_array(JsonMachine::class."::$methodName", $args);
         $this->assertSame($expected, iterator_to_array($iterator));
+        // Assert it can be iterated more than once
+        $this->assertSame($expected, iterator_to_array($iterator));
     }
 
     public function dataFactories()


### PR DESCRIPTION
### Problem

A JsonMachine based on a stream (StreamBytes iterator) can not be iterated more than once.

### Reproduce

```
$jm = JsonMachine::fromStream(fopen('data://text/plain,{"path": {"key":"value"}}', 'r'));
foreach($jm as $item) {
    echo $item;
}
foreach($jm as $item) {
    echo $item;
}
```

This results in `JsonMachine\Exception\SyntaxError: Cannot iterate empty JSON '' At position 0.` (and `value` is printed only once).

### Proposed solution

Rewind the stream inside the StreamBytes' Generator.