### PR TITLE
Incomplete JSON buffer after composite value containing an empty dict fixed

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -194,6 +194,7 @@ class Parser implements \IteratorAggregate, PositionAware
                     $expectedType = 55; // 55 = self::AFTER_ARRAY_START;
                     continue 2; // valid json chunk is not completed yet
                 case '}':
+                    $objectKeyExpected = false;
                 case ']':
                     --$currentLevel;
                     $inObject = $stack[$currentLevel] === '{';

--- a/test/JsonMachineTest/ParserTest.php
+++ b/test/JsonMachineTest/ParserTest.php
@@ -56,6 +56,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             ['/0/0', '[{"0":{"c":1,"d":2}}]', ['c'=>1,'d'=>2]],
             ['/1/1', '[0,{"1":{"c":1,"d":2}}]', ['c'=>1,'d'=>2]],
             'PR-19-FIX' => ['/datafeed/programs/1', file_get_contents(__DIR__.'/PR-19-FIX.json'), ['program_info'=>['id'=>'X1']]],
+            'ISSUE-41-FIX' => ['/path', '{"path":[{"empty":{}},{"value":1}]}', [["empty"=>[]],["value"=>1]]],
         ];
     }
 


### PR DESCRIPTION
When the last value of a decoded object item was an empty object, the next object item failed to decode, because the opening `{` was missing in the buffered to-be-decoded JSON item.

Solves #41 