### PR TITLE
Let JSON pointer iterate through values in nested arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## master
-Nothing yet
+- Use `-` in json pointer as a wildcard in arrays. Example: `/users/-/id`
 
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -159,6 +159,29 @@ foreach ($fruits as $name => $data) {
 > `results` at a time. It is always one item in memory at a time at the level/subtree
 > you are currently iterating. Thus, the memory consumption is constant.
 
+Json Pointer spec also allows using hyphen (`-`) instead of specific value of an array index. Json Machine interprets
+this as a wildcard which matches any **array index** (not any object key). This enables you to iterate nested values in
+arrays without loading the whole item.
+
+Example:
+```json
+// fruitsArray.json
+{
+    "results": [
+        {
+            "name": "apple",
+            "color": "red"
+        },
+        {
+            "name": "pear",
+            "color": "yellow"
+        }
+    ]
+}
+```
+
+To iterate over all colors of the fruits use json pointer `"/results/-/color"`.
+
 <a name="json-pointer"></a>
 #### What is Json Pointer?
 It's a way of addressing one item in JSON document. See the [Json Pointer RFC 6901](https://tools.ietf.org/html/rfc6901).

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ foreach ($fruits as $name => $data) {
 > `results` at a time. It is always one item in memory at a time at the level/subtree
 > you are currently iterating. Thus, the memory consumption is constant.
 
-Json Pointer spec also allows using hyphen (`-`) instead of specific value of an array index. Json Machine interprets
-this as a wildcard which matches any **array index** (not any object key). This enables you to iterate nested values in
+The JSON Pointer spec also allows to use a hyphen (`-`) instead of a specific array index. JSON Machine interprets
+it as a wildcard which matches any **array index** (not any object key). This enables you to iterate nested values in
 arrays without loading the whole item.
 
 Example:
@@ -180,7 +180,7 @@ Example:
 }
 ```
 
-To iterate over all colors of the fruits use json pointer `"/results/-/color"`.
+To iterate over all colors of the fruits, use the JSON pointer `"/results/-/color"`.
 
 <a name="json-pointer"></a>
 #### What is Json Pointer?

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Some examples:
 |--------------------|---------------------------------------------------------------------------------------------------|
 | `""` (empty string - default)     | `["this", "array"]` or `{"a": "this", "b": "object"}` will be iterated (main level) |
 | `"/result/items"`    | `{"result":{"items":["this","array","will","be","iterated"]}}`                                    |
+| `"/results/-/status"`| `{"results":[{"status": "iterated"}, {"status": "also iterated"}]}`                               |
 | `"/0/items"`         | `[{"items":["this","array","will","be","iterated"]}]` (supports array indices)                    |
 | `"/"` (gotcha! - a slash followed by an empty string, see the [spec](https://tools.ietf.org/html/rfc6901#section-5))      | `{"":["this","array","will","be","iterated"]}`              |
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -28,8 +28,6 @@ class Parser implements \IteratorAggregate, PositionAware
     const AFTER_ARRAY_VALUE = self::COMMA | self::ARRAY_END;
     const AFTER_OBJECT_VALUE = self::COMMA | self::OBJECT_END;
 
-    const JSON_POINTER_LOOP = '-';
-
     /** @var Lexer */
     private $lexer;
 
@@ -109,6 +107,7 @@ class Parser implements \IteratorAggregate, PositionAware
         $subtreeEnded = false;
         $token = null;
 
+        // local variables for faster name lookups
         $lexer = $this->lexer;
         $jsonPointerPath = $this->jsonPointerPath;
         
@@ -119,8 +118,8 @@ class Parser implements \IteratorAggregate, PositionAware
             }
             $isValue = ($tokenType | 23) === 23; // 23 = self::ANY_VALUE
             if ( ! $inObject && $isValue && $currentLevel < $iteratorLevel) {
-                if ($this->jsonPointerPath[$currentLevel] === self::JSON_POINTER_LOOP) {
-                    $currentPath[$currentLevel] = self::JSON_POINTER_LOOP;
+                if ($jsonPointerPath[$currentLevel] === '-') {
+                    $currentPath[$currentLevel] = '-';
                 } else {
                     $currentPath[$currentLevel] = isset($currentPath[$currentLevel]) ? (string)(1+(int)$currentPath[$currentLevel]) : "0";
                 }

--- a/test/JsonMachineTest/ParserTest.php
+++ b/test/JsonMachineTest/ParserTest.php
@@ -236,6 +236,56 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(["result" => "one"], iterator_to_array($parser));
     }
 
+    public function testGeneratorYieldsNestedValues()
+    {
+        $json = '
+            {
+                "zero": [
+                    {
+                        "one": "ignored",
+                        "two": [
+                            {
+                                "three": 1
+                            }
+                        ],
+                        "four": [
+                            {
+                                "five": "ignored"
+                            }
+                        ]
+                    },
+                    {
+                        "one": 1,
+                        "two": [
+                            {
+                                "three": 2
+                            },
+                            {
+                                "three": 3
+                            }
+                        ],
+                        "four": [
+                            {
+                                "five": "ignored"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ';
+
+        $parser = $this->createParser($json, '/zero/-/two/-/three');
+
+        $i = 0;
+        $expectedKey = 'three';
+        $expectedValues = [1, 2, 3];
+
+        foreach ($parser as $key => $value) {
+            $this->assertSame($expectedKey, $key);
+            $this->assertSame($expectedValues[$i++], $value);
+        }
+    }
+
     private function createParser($json, $jsonPointer = '')
     {
         return new Parser(new Lexer(new \ArrayIterator([$json])), $jsonPointer);

--- a/test/JsonMachineTest/ParserTest.php
+++ b/test/JsonMachineTest/ParserTest.php
@@ -57,6 +57,9 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             ['/1/1', '[0,{"1":{"c":1,"d":2}}]', ['c'=>1,'d'=>2]],
             'PR-19-FIX' => ['/datafeed/programs/1', file_get_contents(__DIR__.'/PR-19-FIX.json'), ['program_info'=>['id'=>'X1']]],
             'ISSUE-41-FIX' => ['/path', '{"path":[{"empty":{}},{"value":1}]}', [["empty"=>[]],["value"=>1]]],
+            ['/-', '[{"one": 1,"two": 2},{"three": 3,"four": 4}]', ['one'=>1, 'two'=>2, 'three'=>3, 'four'=>4]],
+            ['/zero/-', '{"zero":[{"one": 1,"two": 2},{"three": 3,"four": 4}]}', ['one'=>1, 'two'=>2, 'three'=>3, 'four'=>4]],
+            ['/zero/-/three', '{"zero":[{"one": 1,"two": 2},{"three": 3,"four": 4}]}', ['three'=>3]]
         ];
     }
 


### PR DESCRIPTION
Hi @halaxa and thanks for this brilliant package :)

Based on [RFC 6901](https://tools.ietf.org/html/rfc6901), the character `-` can reference a JSON array and applications using a JSON pointer can specify how it should handle such character. In particular:

> If the currently referenced value is a JSON array, the reference
      token MUST contain either:
>
>    *  characters comprised of digits [...], or
>
>    *  exactly the single character "-", making the new referenced
          value the (nonexistent) member after the last array element.

and

> Note that the use of the "-" character to index an array will always
   result in such an error condition because by definition it refers to
   a nonexistent array element.  Thus, applications of JSON Pointer need
   to specify how that character is to be handled, if it is to be
   useful.
>
 >  Any error condition for which a specific action is not defined by the
   JSON Pointer application results in termination of evaluation.


This PR aims to take advantage of this spec to let the JSON pointer iterate through values in nested arrays.

For example, given the following JSON:
```json
{
    "data": [
        {
            "name": "Team 1",
            "users": [
                {
                    "id": 1
                },
                {
                    "id": 2
                }
            ]
        },
        {
            "name": "Team 2",
            "users": [
                {
                    "id": 3
                }
            ]
        }
    ]
}
```
the JSON pointer `/data/-/users/-/id` will iterate through all user IDs.

This PR also tests the feature and updates the README.