### PR TITLE
Fix the parsing of nested sub-trees that use wildcards

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -17,6 +17,8 @@ jobs:
     - uses: satackey/action-docker-layer-caching@v0.0.11
       # Ignore the failure of a step and avoid terminating the job.
       continue-on-error: true
+      with:
+        key: docker-image-version-1-{hash}
 
     - name: Complete Makefile build
       run: make build

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -126,7 +126,7 @@ class Parser implements \IteratorAggregate, PositionAware
                 array_splice($currentPathWildcard, $currentLevel + 1);
             }
             if (
-                (
+                (   // array_diff may be replaced with '==' when PHP 7 stops being supported
                     ! array_diff($jsonPointerPath, $currentPath)
                     || ! array_diff($jsonPointerPath, $currentPathWildcard)
                 )

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -290,9 +290,9 @@ class Parser implements \IteratorAggregate, PositionAware
     {
         $matchingPointerByIndex = [];
 
-        foreach ($this->paths as $jsonPointer => $jsonPointerSegments) {
-            foreach ($this->currentPath as $index => $segment) {
-                if (!isset($jsonPointerSegments[$index]) || !$this->pathMatchesPointer($segment, $jsonPointerSegments[$index])) {
+        foreach ($this->paths as $jsonPointer => $referenceTokens) {
+            foreach ($this->currentPath as $index => $pathToken) {
+                if (!isset($referenceTokens[$index]) || !$this->pathMatchesPointer($pathToken, $referenceTokens[$index])) {
                     continue 2;
                 } elseif (!isset($matchingPointerByIndex[$index])) {
                     $matchingPointerByIndex[$index] = $jsonPointer;
@@ -389,18 +389,18 @@ class Parser implements \IteratorAggregate, PositionAware
     }
 
     /**
-     * Determine whether the given path segment matches the provided JSON pointer segment
+     * Determine whether the given path reference token matches the provided JSON pointer reference token
      *
-     * @param string|int $pathSegment
-     * @param string $pointerSegment
+     * @param string|int $pathToken
+     * @param string $pointerToken
      * @return bool
      */
-    private function pathMatchesPointer($pathSegment, string $pointerSegment): bool
+    private function pathMatchesPointer($pathToken, string $pointerToken): bool
     {
-        if ($pointerSegment === (string) $pathSegment) {
+        if ($pointerToken === (string) $pathToken) {
             return true;
         }
 
-        return is_int($pathSegment) && $pointerSegment === '-';
+        return is_int($pathToken) && $pointerToken === '-';
     }
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -234,13 +234,13 @@ class Parser implements \IteratorAggregate, PositionAware
                 unset($valueResult);
             }
             if (
-                    ! array_diff($jsonPointerPath, $currentPath)
-                    || ! array_diff($jsonPointerPath, $currentPathWildcard)
+                ! array_diff($jsonPointerPath, $currentPath)
+                || ! array_diff($jsonPointerPath, $currentPathWildcard)
             ) {
                 if ( ! in_array($this->matchedJsonPointer, $pointersFound, true)) {
                     $pointersFound[] = $this->matchedJsonPointer;
                 }
-            } elseif (count($pointersFound) == count($this->jsonPointers) && !$this->inJsonPointer()) {
+            } elseif (count($pointersFound) == count($this->jsonPointers) && ! $this->inJsonPointer()) {
                 $subtreeEnded = true;
                 break;
             }
@@ -301,9 +301,9 @@ class Parser implements \IteratorAggregate, PositionAware
 
         foreach ($this->paths as $jsonPointer => $referenceTokens) {
             foreach ($this->currentPath as $index => $pathToken) {
-                if (!isset($referenceTokens[$index]) || !$this->pathMatchesPointer($pathToken, $referenceTokens[$index])) {
+                if ( ! isset($referenceTokens[$index]) || ! $this->pathMatchesPointer($pathToken, $referenceTokens[$index])) {
                     continue 2;
-                } elseif (!isset($matchingPointerByIndex[$index])) {
+                } elseif ( ! isset($matchingPointerByIndex[$index])) {
                     $matchingPointerByIndex[$index] = $jsonPointer;
                 }
             }
@@ -382,9 +382,7 @@ class Parser implements \IteratorAggregate, PositionAware
     }
 
     /**
-     * Determine whether the current position is within one of the JSON pointers
-     *
-     * @return bool
+     * Determine whether the current position is within one of the JSON pointers.
      */
     private function inJsonPointer(): bool
     {
@@ -398,11 +396,9 @@ class Parser implements \IteratorAggregate, PositionAware
     }
 
     /**
-     * Determine whether the given path reference token matches the provided JSON pointer reference token
+     * Determine whether the given path reference token matches the provided JSON pointer reference token.
      *
      * @param string|int $pathToken
-     * @param string $pointerToken
-     * @return bool
      */
     private function pathMatchesPointer($pathToken, string $pointerToken): bool
     {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -127,8 +127,8 @@ class Parser implements \IteratorAggregate, PositionAware
             }
             if (
                 (
-                    $jsonPointerPath == $currentPath
-                    || $jsonPointerPath == $currentPathWildcard
+                    ! array_diff($jsonPointerPath, $currentPath)
+                    || ! array_diff($jsonPointerPath, $currentPathWildcard)
                 )
                 && (
                     $currentLevel > $iteratorLevel
@@ -233,7 +233,10 @@ class Parser implements \IteratorAggregate, PositionAware
                 }
                 unset($valueResult);
             }
-            if ($jsonPointerPath == $currentPath || $jsonPointerPath == $currentPathWildcard) {
+            if (
+                    ! array_diff($jsonPointerPath, $currentPath)
+                    || ! array_diff($jsonPointerPath, $currentPathWildcard)
+            ) {
                 if ( ! in_array($this->matchedJsonPointer, $pointersFound, true)) {
                     $pointersFound[] = $this->matchedJsonPointer;
                 }

--- a/test/JsonMachineTest/ParserTest.php
+++ b/test/JsonMachineTest/ParserTest.php
@@ -124,7 +124,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         return [
             'non existing pointer' => ['{}', '/not/found'],
             "empty string should not match '0'" => ['{"0":[]}', '/'],
-            'empty string should not match 0' => ['[[]]', '/'],
+            'empty string should not match 0 index' => ['[[]]', '/'],
             '0 should not match empty string' => ['{"":[]}', '/0'],
         ];
     }

--- a/test/JsonMachineTest/ParserTest.php
+++ b/test/JsonMachineTest/ParserTest.php
@@ -281,14 +281,64 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 
         $parser = $this->createParser($json, '/zero/-/two/-/three');
 
-        $i = 0;
-        $expectedKey = 'three';
-        $expectedValues = [1, 2, 3];
+        $actual = [];
+        $expected = ['three' => [1, 2, 3]];
 
         foreach ($parser as $key => $value) {
-            $this->assertSame($expectedKey, $key);
-            $this->assertSame($expectedValues[$i++], $value);
+            $actual[$key][] = $value;
         }
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testGeneratorYieldsNestedValuesOfMultiplePaths()
+    {
+        $json = '
+            {
+                "zero": [
+                    {
+                        "one": "hello",
+                        "two": [
+                            {
+                                "three": 1
+                            }
+                        ],
+                        "four": [
+                            {
+                                "five": "ignored"
+                            }
+                        ]
+                    },
+                    {
+                        "one": "bye",
+                        "two": [
+                            {
+                                "three": 2
+                            },
+                            {
+                                "three": 3
+                            }
+                        ],
+                        "four": [
+                            {
+                                "five": "ignored"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ';
+
+        $parser = $this->createParser($json, ['/zero/-/one', '/zero/-/two/-/three']);
+
+        $actual = [];
+        $expected = ['one' => ['hello', 'bye'], 'three' => [1, 2, 3]];
+
+        foreach ($parser as $key => $value) {
+            $actual[$key][] = $value;
+        }
+
+        $this->assertSame($expected, $actual);
     }
 
     private function createParser($json, $jsonPointer = '')


### PR DESCRIPTION
Hey @halaxa! Long time since [our last PR](https://github.com/halaxa/json-machine/pull/47)! 😄

Your package keeps improving, I love the support for multiple JSON pointers ❤️ 

While updating [my package](https://github.com/cerbero90/lazy-json) (based on yours), I noticed that some changes are interrupting the iteration of nested sub-trees at the first matching JSON object and ignore the remaining iterations. Which appears to be the issue flagged here: https://github.com/halaxa/json-machine/issues/78

This PR aims to bring the following changes:
- let indexes of JSON arrays be integer within the current path. This brings 2 benefits:
  - accurate current path, JSON array indexes are actually integers
  - avoid the use of regular expressions to perform checks against parts of the path
- fix how we compute the current path and current path wildcard
  - currently these paths are not cleaned when the current level drops by 2 or more levels
- fix the parsing of nested sub-trees that use wildcards
  - currently they are interrupted after the first iteration
- simplify and make the logic to compute the matching JSON pointer more accurate
- improve and add one more test for parsing nested sub-trees using wildcards