### PR TITLE
Only complete pointer paths now considered intersecting

### DIFF
--- a/src/ValidJsonPointers.php
+++ b/src/ValidJsonPointers.php
@@ -64,8 +64,8 @@ final class ValidJsonPointers
                     continue;
                 }
                 if ($jsonPointerA === $jsonPointerB
-                    || self::str_contains($jsonPointerA, $jsonPointerB)
-                    || self::str_contains($jsonPointerA, self::wildcardify($jsonPointerB))
+                    || self::str_contains("$jsonPointerA/", "$jsonPointerB/")
+                    || self::str_contains("$jsonPointerA/", self::wildcardify("$jsonPointerB/"))
                 ) {
                     throw new InvalidArgumentException(
                         sprintf(

--- a/test/JsonMachineTest/ValidJsonPointersTest.php
+++ b/test/JsonMachineTest/ValidJsonPointersTest.php
@@ -85,6 +85,8 @@ class ValidJsonPointersTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['/one', '/two'],
+            ['/companies/-/id', '/companies/0/idempotency_key'],
+            ['/companies/1/id', '/companies/1/idempotency_key'],
         ];
     }
 }

--- a/test/JsonMachineTest/ValidJsonPointersTest.php
+++ b/test/JsonMachineTest/ValidJsonPointersTest.php
@@ -70,11 +70,21 @@ class ValidJsonPointersTest extends \PHPUnit_Framework_TestCase
         (new ValidJsonPointers(['/one', '/one']))->toArray();
     }
 
-    public function testToArrayReturnsJsonPointers()
+    /**
+     * @dataProvider data_testToArrayReturnsJsonPointers
+     */
+    public function testToArrayReturnsJsonPointers(string $pointerA, string $pointerB)
     {
         $this->assertSame(
-            ['/one', '/two'],
-            (new ValidJsonPointers(['/one', '/two']))->toArray()
+            [$pointerA, $pointerB],
+            (new ValidJsonPointers([$pointerA, $pointerB]))->toArray()
         );
+    }
+
+    public function data_testToArrayReturnsJsonPointers()
+    {
+        return [
+            ['/one', '/two'],
+        ];
     }
 }


### PR DESCRIPTION
This fixes halaxa/json-machine#106 by adding a path separator to terminate each pointer when comparing for intersection.