### PR TITLE
Missing PHP-Doc PathNotFoundException 

### DIFF
--- a/src/FileChunks.php
+++ b/src/FileChunks.php
@@ -24,6 +24,7 @@ class FileChunks implements \IteratorAggregate
 
     /**
      * @return \Generator
+     *
      * @throws Exception\InvalidArgumentException
      */
     #[\ReturnTypeWillChange]

--- a/src/FileChunks.php
+++ b/src/FileChunks.php
@@ -24,6 +24,7 @@ class FileChunks implements \IteratorAggregate
 
     /**
      * @return \Generator
+     * @throws Exception\InvalidArgumentException
      */
     #[\ReturnTypeWillChange]
     public function getIterator()

--- a/src/Items.php
+++ b/src/Items.php
@@ -117,6 +117,7 @@ final class Items implements \IteratorAggregate, PositionAware
 
     /**
      * @return \Generator
+     *
      * @throws Exception\PathNotFoundException
      */
     #[\ReturnTypeWillChange]

--- a/src/Items.php
+++ b/src/Items.php
@@ -117,6 +117,7 @@ final class Items implements \IteratorAggregate, PositionAware
 
     /**
      * @return \Generator
+     * @throws Exception\PathNotFoundException
      */
     #[\ReturnTypeWillChange]
     public function getIterator()
@@ -124,6 +125,9 @@ final class Items implements \IteratorAggregate, PositionAware
         return $this->parser->getIterator();
     }
 
+    /**
+     * @throws Exception\JsonMachineException
+     */
     public function getPosition()
     {
         return $this->parser->getPosition();
@@ -134,11 +138,17 @@ final class Items implements \IteratorAggregate, PositionAware
         return $this->parser->getJsonPointers();
     }
 
+    /**
+     * @throws Exception\JsonMachineException
+     */
     public function getCurrentJsonPointer(): string
     {
         return $this->parser->getCurrentJsonPointer();
     }
 
+    /**
+     * @throws Exception\JsonMachineException
+     */
     public function getMatchedJsonPointer(): string
     {
         return $this->parser->getMatchedJsonPointer();

--- a/src/ItemsOptions.php
+++ b/src/ItemsOptions.php
@@ -12,6 +12,9 @@ class ItemsOptions extends \ArrayObject
 {
     private $options = [];
 
+    /**
+     * @throws InvalidArgumentException
+     */
     public function __construct(array $options = [])
     {
         $this->validateOptions($options);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -321,6 +321,9 @@ class Parser implements \IteratorAggregate, PositionAware
         return array_values($this->jsonPointers);
     }
 
+    /**
+     * @throws JsonMachineException
+     */
     public function getCurrentJsonPointer(): string
     {
         if ($this->currentPath === null) {
@@ -330,6 +333,9 @@ class Parser implements \IteratorAggregate, PositionAware
         return self::pathToJsonPointer($this->currentPath);
     }
 
+    /**
+     * @throws JsonMachineException
+     */
     public function getMatchedJsonPointer(): string
     {
         if ($this->matchedJsonPointer === null) {

--- a/src/StreamChunks.php
+++ b/src/StreamChunks.php
@@ -16,7 +16,8 @@ class StreamChunks implements \IteratorAggregate
 
     /**
      * @param resource $stream
-     * @param int $chunkSize
+     * @param int      $chunkSize
+     *
      * @throws InvalidArgumentException
      */
     public function __construct($stream, $chunkSize = 1024 * 8)

--- a/src/StreamChunks.php
+++ b/src/StreamChunks.php
@@ -16,7 +16,8 @@ class StreamChunks implements \IteratorAggregate
 
     /**
      * @param resource $stream
-     * @param int      $chunkSize
+     * @param int $chunkSize
+     * @throws InvalidArgumentException
      */
     public function __construct($stream, $chunkSize = 1024 * 8)
     {


### PR DESCRIPTION
On Items.php 
```php
/**
     * @return \Generator
     */
    #[\ReturnTypeWillChange]
    public function getIterator()
    {
        return $this->parser->getIterator();
    }
```

please add @throws PathNotFoundException as it will not be recognised in PHP-Storm as Throwable Exception.