### PR TITLE
ItemsOption, PHP 8.4: → JsonMachine\ItemsOptions::opt_decoder(): Implicitly marking parameter $decoder as nullable is deprecated, the explicit nullable type must be used instead

### DIFF
--- a/src/ItemsOptions.php
+++ b/src/ItemsOptions.php
@@ -59,7 +59,7 @@ class ItemsOptions extends \ArrayObject
         return $pointer;
     }
 
-    private function opt_decoder(ItemDecoder $decoder = null)
+    private function opt_decoder(?ItemDecoder $decoder = null)
     {
         return $decoder;
     }


### PR DESCRIPTION
→ JsonMachine\ItemsOptions::opt_decoder(): Implicitly marking parameter $decoder as nullable is deprecated, the explicit nullable type must be used instead